### PR TITLE
add n_consec_matches param

### DIFF
--- a/akmerbroom.py
+++ b/akmerbroom.py
@@ -19,6 +19,8 @@ def main():
     parser.add_argument('--ancient_kmers_set', help='Use if ancient kmers set provided (defaults to False)',
                         action='store_true', required=False)
     parser.add_argument('--kmer_size', help='Set kmer size (defaults to 31)', required=False)
+    parser.add_argument('--n_consec_matches', help="Set number of consec matches to classify read as anchor read, \
+                                                   (defaults to 2)", required=False)
     parser.add_argument('--anchor_proportion_cutoff', help="Set anchor kmer proportion, \
         above which a read is classified as ancient (defaults to 0.5)",
                         required=False)
@@ -76,6 +78,12 @@ def main():
     if args['ancient_kmers_set']:
         ancient_kmers = True
 
+    # set n_consec_matches cutoff
+    if not args['n_consec_matches']:
+        n_consec_matches = 2
+    else:
+        anchor_proportion_cutoff = int(args['n_consec_matches'])
+
     # set anchor proportion cutoff
     if not args['anchor_proportion_cutoff']:
         anchor_proportion_cutoff = 0.5
@@ -86,8 +94,16 @@ def main():
     # declare defaults
     logger.info("Using default of k=31 and input folder='data'")
     logger.info("Shortlisting ancient reads")
-    anchor_kmer_set = classify_reads.classify_reads(bloom_filt, bf_capacity, ancient_kmers, k_size,output)
-    classify_reads.classify_reads_using_anchor_kmers(anchor_kmer_set, k_size, anchor_proportion_cutoff,output)
+    anchor_kmer_set = classify_reads.classify_reads(bloom_filt,
+                                                    bf_capacity,
+                                                    ancient_kmers,
+                                                    k_size,
+                                                    n_consec_matches,
+                                                    output)
+    classify_reads.classify_reads_using_anchor_kmers(anchor_kmer_set,
+                                                     k_size,
+                                                     anchor_proportion_cutoff,
+                                                     output)
     logger.info("Completed successfully")
 
 

--- a/akmerbroom.py
+++ b/akmerbroom.py
@@ -82,7 +82,7 @@ def main():
     if not args['n_consec_matches']:
         n_consec_matches = 2
     else:
-        anchor_proportion_cutoff = int(args['n_consec_matches'])
+        n_consec_matches = int(args['n_consec_matches'])
 
     # set anchor proportion cutoff
     if not args['anchor_proportion_cutoff']:

--- a/scripts/classify_reads.py
+++ b/scripts/classify_reads.py
@@ -34,7 +34,7 @@ def getbloomFilter(bf, bf_capacity, ancient_kmers, kmer_size):
     return ancient_kmers_bf
 
 
-def classify_reads(bf, bf_capacity, ancient_kmers, kmer_size,output):
+def classify_reads(bf, bf_capacity, ancient_kmers, kmer_size, n_consecutive_matches, output):
     ancient_kmers_bf = getbloomFilter(bf, bf_capacity, ancient_kmers, kmer_size)
     unknown_reads_file = "data/unknown_reads.fastq"
     annotated_reads_file = open(output+"/annotated_reads.fastq", "w")
@@ -67,9 +67,10 @@ def classify_reads(bf, bf_capacity, ancient_kmers, kmer_size,output):
         for i in range(kmer_size-1):
             matches.append(12)       # need to add an extra k-1 empty matches since kmers are now all out
 
-        # get is_consecutive (i.e. at least 2 matches in a row)
+        # test if consecutive_matches is greater than or equal to n_consecutive_matches parameter
         stringified_matches = ''.join(str(match) for match in matches)
-        if '00' in stringified_matches:
+        consecutive_matches_string = n_consecutive_matches*'0'
+        if consecutive_matches_string in stringified_matches:
             consecutive_matches_found = 1
 
         if consecutive_matches_found:


### PR DESCRIPTION
Add a parameter to allow user to specify a number of consecutive matches for a read to be an anchor read. This lets us test consec matches > 2 (which was earlier hard-coded).